### PR TITLE
cluster-instance-tag: numeric org ids

### DIFF
--- a/lib/tasks/cluster-instance-tag.js
+++ b/lib/tasks/cluster-instance-tag.js
@@ -2,6 +2,7 @@
 
 require('loadenv')('shiva:env');
 
+var exists = require('101/exists');
 var isString = require('101/is-string');
 var isObject = require('101/is-object');
 var error = require('../error');
@@ -45,10 +46,10 @@ function clusterInstanceTag(job) {
     ));
   }
 
-  if (!isString(job.org)) {
+  if (!exists(job.org)) {
     return error.rejectAndReport(new TaskFatalError(
       'cluster-instance-tag',
-      'Job missing `org` field of type {string}',
+      'Job missing `org` field',
       { job: job }
     ));
   }

--- a/test/unit/tasks/cluster-instance-tag.js
+++ b/test/unit/tasks/cluster-instance-tag.js
@@ -85,6 +85,18 @@ describe('tasks', function() {
       });
     });
 
+    it('should allow numeric `org` tag', function(done) {
+      var job = {
+        org: 1345,
+        role: 'dock',
+        instanceId: 'some-id'
+      };
+      clusterInstanceTag(job).asCallback(function (err) {
+        expect(err).to.not.exist();
+        done();
+      });
+    });
+
     it('should call aws `createTags` with the correct tags', function(done) {
       var instanceId = '1';
       var job = {


### PR DESCRIPTION
Allow the `cluster-instance-tag` task handler to accept numeric `org` parameters (github ids are just numbers afterall).
