### PR TITLE
SAN-2612 Production now defaults to c3.large instances

### DIFF
--- a/configs/.env.production
+++ b/configs/.env.production
@@ -13,7 +13,7 @@ AWS_INSTANCE_IMAGE_ID=ami-55b47311
 AWS_INSTANCE_IMAGE_NAME=alpha-build-run-dock-2.0.3
 
 # Default dock instance type and number to spawn on `cluster-provision`
-AWS_INSTANCE_TYPE=c3.xlarge
+AWS_INSTANCE_TYPE=c3.large
 CLUSTER_INITIAL_DOCKS=3
 
 # Dock Instance Volume Parameters


### PR DESCRIPTION
Per request from product.

TODO:
- [x] 100% Unit Tested
- [x] Integration Tested
