### PR TITLE
Ensure `cluster-provision` casts `githubId` to String

### DIFF
--- a/lib/shiva/tasks/cluster-provision.js
+++ b/lib/shiva/tasks/cluster-provision.js
@@ -2,7 +2,6 @@
 
 require('loadenv')({ project: 'shiva', debugName: 'astral:shiva:env' });
 
-var exists = require('101/exists');
 var isObject = require('101/is-object');
 var isString = require('101/is-string');
 var Cluster = require('../models/cluster');
@@ -35,16 +34,16 @@ function clusterProvision(job) {
       );
     }
 
-    if (!exists(job.githubId)) {
+    if (!Number.isInteger(job.githubId) && !isString(job.githubId)) {
       throw new TaskFatalError(
         'cluster-provision',
-        'Job missing `githubId` field',
+        'Job missing `githubId` field of type {string} or {integer}',
         { job: job }
       );
     }
 
     // Ensure the github id is a string moving forward
-    if (!isString(job.githubId)) {
+    if (Number.isInteger(job.githubId)) {
       job.githubId = job.githubId.toString();
     }
 

--- a/test/shiva/unit/tasks/cluster-provision.js
+++ b/test/shiva/unit/tasks/cluster-provision.js
@@ -55,6 +55,14 @@ describe('shiva', function() {
         });
       });
 
+      it('should fatally reject if the `githubId` is not an integer nor a string', function(done) {
+        clusterProvision({ githubId: {} }).asCallback(function (err) {
+          expect(err).to.be.an.instanceof(TaskFatalError);
+          expect(err.message).to.match(/missing.*githubId/);
+          done();
+        })
+      });
+
       it('should check to see if a cluster already exists', function(done) {
         var githubId = '1234';
         Cluster.githubOrgExists.returns(Promise.resolve(true));


### PR DESCRIPTION
The `cluster-provision` endpoint allows the `job.githubid` field to be an integer or a string. The other workers are a little more strict and require that the id be a string. This fixes the worker to ensure that when `cluster-provision` is passed an integer, it casts it to a string before publishing the `cluster-instance-provision` jobs.

TODO:
- [x] 100% Unit Tested
- [x] Integration Tested
- [x] Tested on Beta
