### PR TITLE
SAN-3119; New ASG Queue Names

### DIFF
--- a/integration/shiva/tasks/auto-scaling-groups.js
+++ b/integration/shiva/tasks/auto-scaling-groups.js
@@ -55,9 +55,9 @@ describe('shiva', function() {
           .asCallback(done);
       });
 
-      describe('shiva-asg-create', function() {
+      describe('shiva.asg.create', function() {
         it('should create an auto-scaling group', function(done) {
-          server.hermes.publish('shiva-asg-create', { githubId: githubId });
+          server.hermes.publish('shiva.asg.create', { githubId: githubId });
           var attempt = 0;
           var checkInterval = setInterval(function () {
             AutoScalingGroup.get(githubId)
@@ -79,9 +79,9 @@ describe('shiva', function() {
               .catch(done);
           }, checkDelay);
         });
-      }); // end 'shiva-asg-create'
+      }); // end 'shiva.asg.create'
 
-      describe('shiva-asg-update', function () {
+      describe('shiva.asg.update', function () {
         it('should update the auto-scaling group', function (done) {
           var maxSize = 8;
           var job = {
@@ -91,7 +91,7 @@ describe('shiva', function() {
             }
           };
 
-          server.hermes.publish('shiva-asg-update', job);
+          server.hermes.publish('shiva.asg.update', job);
 
           var attempt = 0;
           var checkInterval = setInterval(function () {
@@ -115,11 +115,11 @@ describe('shiva', function() {
               .catch(done);
           }, checkDelay);
         });
-      }); // end 'shiva-asg-update'
+      }); // end 'shiva.asg.update'
 
-      describe('shiva-asg-delete', function () {
+      describe('shiva.asg.delete', function () {
         it('should remove an auto-scaling group', function (done) {
-          server.hermes.publish('shiva-asg-delete', { githubId: githubId });
+          server.hermes.publish('shiva.asg.delete', { githubId: githubId });
           var attempt = 0;
           var checkInterval = setInterval(function () {
             AutoScalingGroup.get(githubId)
@@ -138,7 +138,7 @@ describe('shiva', function() {
               .catch(done);
           }, checkDelay);
         });
-      }); // end 'shiva-asg-delete'
+      }); // end 'shiva.asg.delete'
     }); // end 'tasks'
   }); // end 'integration'
 }); // end 'shiva'

--- a/lib/shiva/server.js
+++ b/lib/shiva/server.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var isFunction = require('101/is-function');
 var log = require('./logger');
 var ponos = require('ponos');
 
@@ -18,11 +19,21 @@ var queues = [
   'cluster-instance-delete',
   'cluster-deprovision',
   'cluster-delete',
-  // New-world queues. ASG based build clusters...
-  'shiva-asg-create',
-  'shiva-asg-delete',
-  'shiva-asg-update'
+  // New-world queues, ASG based build clusters...
+  'shiva.asg.create',
+  'shiva.asg.delete',
+  'shiva.asg.update'
 ];
+
+/**
+ * Task handlers for new style queues (can no longer just use the file name).
+ * @type {object}
+ */
+var queueTasks = {
+  'shiva.asg.create': require('./tasks/shiva-asg-create'),
+  'shiva.asg.delete': require('./tasks/shiva-asg-delete'),
+  'shiva.asg.update': require('./tasks/shiva-asg-update')
+};
 
 /**
  * Singelton instance of the worker server.
@@ -32,6 +43,9 @@ var server = module.exports = new ponos.Server({ queues: queues, log: log });
 
 // Set the task handlers for each queue
 queues.forEach(function (name) {
-  var task = require('./tasks/' + name);
+  var task = queueTasks[name];
+  if (!isFunction(task)) {
+    task = require('./tasks/' + name);
+  }
   server.setTask(name, task);
 });

--- a/lib/shiva/tasks/shiva-asg-create.js
+++ b/lib/shiva/tasks/shiva-asg-create.js
@@ -10,7 +10,7 @@ var TaskFatalError = require('ponos').TaskFatalError;
 var Promise = require('bluebird');
 
 /**
- * Task handler for the `shiva-asg-provision` queue.
+ * Task handler for the `shiva.asg.provision` queue.
  * @author Ryan Sandor Richards
  * @module astral:shiva:tasks
  */
@@ -28,21 +28,21 @@ function shivaASGProvision(job) {
     .try(function validateJob() {
       if (!isObject(job)) {
         throw new TaskFatalError(
-          'shiva-asg-provision',
+          'shiva.asg.provision',
           'Encountered non-object job',
           { job: job }
         );
       }
       if (!isString(job.githubId)) {
         throw new TaskFatalError(
-          'shiva-asg-provision',
+          'shiva.asg.provision',
           'Job missing `githubId` field of type {string}',
           { job: job }
         );
       }
       if (isEmpty(job.githubId)) {
         throw new TaskFatalError(
-          'shiva-asg-provision',
+          'shiva.asg.provision',
           'Job `githubId` field cannot be empty',
           { job: job }
         );

--- a/lib/shiva/tasks/shiva-asg-delete.js
+++ b/lib/shiva/tasks/shiva-asg-delete.js
@@ -10,7 +10,7 @@ var TaskFatalError = require('ponos').TaskFatalError;
 var Promise = require('bluebird');
 
 /**
- * Task handler for the `shiva-asg-delete` queue.
+ * Task handler for the `shiva.asg.delete` queue.
  * @author Ryan Sandor Richards
  * @module astral:shiva:tasks
  */
@@ -28,21 +28,21 @@ function shivaASGDelete(job) {
     .try(function validateJob() {
       if (!isObject(job)) {
         throw new TaskFatalError(
-          'shiva-asg-delete',
+          'shiva.asg.delete',
           'Encountered non-object job',
           { job: job }
         );
       }
       if (!isString(job.githubId)) {
         throw new TaskFatalError(
-          'shiva-asg-delete',
+          'shiva.asg.delete',
           'Job missing `githubId` field of type {string}',
           { job: job }
         );
       }
       if (isEmpty(job.githubId)) {
         throw new TaskFatalError(
-          'shiva-asg-delete',
+          'shiva.asg.delete',
           'Job `githubId` field cannot be empty',
           { job: job }
         );

--- a/lib/shiva/tasks/shiva-asg-update.js
+++ b/lib/shiva/tasks/shiva-asg-update.js
@@ -10,7 +10,7 @@ var TaskFatalError = require('ponos').TaskFatalError;
 var Promise = require('bluebird');
 
 /**
- * Task handler for the `shiva-asg-update` queue.
+ * Task handler for the `shiva.asg.update` queue.
  * @author Ryan Sandor Richards
  * @module astral:shiva:tasks
  */
@@ -29,28 +29,28 @@ function shivaASGUpdate(job) {
     .try(function validateJobAndUpdateASG() {
       if (!isObject(job)) {
         throw new TaskFatalError(
-          'shiva-asg-update',
+          'shiva.asg.update',
           'Encountered non-object job',
           { job: job }
         );
       }
       if (!isString(job.githubId)) {
         throw new TaskFatalError(
-          'shiva-asg-update',
+          'shiva.asg.update',
           'Job missing `githubId` field of type {string}',
           { job: job }
         );
       }
       if (isEmpty(job.githubId)) {
         throw new TaskFatalError(
-          'shiva-asg-update',
+          'shiva.asg.update',
           'Job `githubId` field cannot be empty',
           { job: job }
         );
       }
       if (!isObject(job.data)) {
         throw new TaskFatalError(
-          'shiva-asg-update',
+          'shiva.asg.update',
           'Job missing `data` field of type {object}',
           { job: job }
         );

--- a/test/shiva/unit/tasks/shiva-asg-create.js
+++ b/test/shiva/unit/tasks/shiva-asg-create.js
@@ -22,7 +22,7 @@ var shivaASGCreate = astralRequire('shiva/tasks/shiva-asg-create');
 
 describe('shiva', function() {
   describe('tasks', function() {
-    describe('shiva-asg-create', function() {
+    describe('shiva.asg.create', function() {
       beforeEach(function (done) {
         sinon.stub(AutoScalingGroup, 'create').returns(Promise.resolve());
         done();
@@ -65,6 +65,6 @@ describe('shiva', function() {
           done();
         });
       });
-    }); // end 'shiva-asg-create'
+    }); // end 'shiva.asg.create'
   }); // end 'tasks'
 }); // end 'shiva'

--- a/test/shiva/unit/tasks/shiva-asg-delete.js
+++ b/test/shiva/unit/tasks/shiva-asg-delete.js
@@ -22,7 +22,7 @@ var shivaASGDelete = astralRequire('shiva/tasks/shiva-asg-delete');
 
 describe('shiva', function() {
   describe('tasks', function() {
-    describe('shiva-asg-delete', function() {
+    describe('shiva.asg.delete', function() {
       beforeEach(function (done) {
         sinon.stub(AutoScalingGroup, 'remove').returns(Promise.resolve());
         done();
@@ -65,6 +65,6 @@ describe('shiva', function() {
           done();
         });
       });
-    }); // end 'shiva-asg-delete'
+    }); // end 'shiva.asg.delete'
   }); // end 'tasks'
 }); // end 'shiva'

--- a/test/shiva/unit/tasks/shiva-asg-update.js
+++ b/test/shiva/unit/tasks/shiva-asg-update.js
@@ -23,7 +23,7 @@ var shivaASGUpdate = astralRequire('shiva/tasks/shiva-asg-update');
 
 describe('shiva', function() {
   describe('tasks', function() {
-    describe('shiva-asg-update', function() {
+    describe('shiva.asg.update', function() {
       beforeEach(function (done) {
         sinon.stub(AutoScalingGroup, 'update').returns(Promise.resolve());
         done();
@@ -79,6 +79,6 @@ describe('shiva', function() {
           done();
         });
       });
-    }); // end 'shiva-asg-update'
+    }); // end 'shiva.asg.update'
   }); // end 'tasks'
 }); // end 'shiva'


### PR DESCRIPTION
Changes the new ASG based queues to use the new queue name style:
- `shiva-asg-create` -> `shiva.asg.create`
- `shiva-asg-update` -> `shiva.asg.update`
- `shiva-asg-delete` -> `shiva.asg.delete`

Note that the changes in `lib/shiva/server.js` are transitional. Eventually all queues will use the same naming convention (after [SAN-2981](https://runnable.atlassian.net/browse/SAN-2981)). 

**JIRA Issues:**
- https://runnable.atlassian.net/browse/SAN-3119

**Reviewers:**
- [x] @anandkumarpatel 
- [x] @podviaznikov 
