### PR TITLE
SAN-3290; Handle AWS Validation Errors

### DIFF
--- a/lib/shiva/errors/aws-validation-error.js
+++ b/lib/shiva/errors/aws-validation-error.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var TaskFatalError = require('ponos').TaskFatalError;
+
+/**
+ * This error is thrown any time we give a method in the AWS SDK invalid data.
+ * @see astral:shiva:models:aws
+ * @module astral:shiva:errors
+ */
+module.exports = class AWSValidationError extends TaskFatalError {
+  constructor (originalError) {
+    super();
+    this.data.originalError = originalError;
+    this.message = originalError.message;
+  }
+};

--- a/lib/shiva/models/util.js
+++ b/lib/shiva/models/util.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var AWSAlreadyExistsError = require('../errors/aws-already-exists-error');
+var AWSValidationError = require('../errors/aws-validation-error');
 
 /**
  * Model utilities for Shiva.
@@ -18,6 +19,9 @@ module.exports = class Util {
   static castAWSError (err) {
     if (err.code === 'AlreadyExists') {
       throw new AWSAlreadyExistsError(err);
+    }
+    else if (err.code === 'ValidationError') {
+      throw new AWSValidationError(err);
     }
     throw err;
   }

--- a/test/shiva/unit/errors/aws-validation-error.js
+++ b/test/shiva/unit/errors/aws-validation-error.js
@@ -1,0 +1,42 @@
+'use strict';
+
+'use strict';
+
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var describe = lab.describe;
+var it = lab.it;
+var before = lab.before;
+var after = lab.after;
+var beforeEach = lab.beforeEach;
+var afterEach = lab.afterEach;
+var Code = require('code');
+var expect = Code.expect;
+var sinon = require('sinon');
+
+var astralRequire = require(process.env.ASTRAL_ROOT + '../test/fixtures/astral-require');
+var loadenv = require('loadenv');
+loadenv.restore();
+loadenv({ project: 'shiva', debugName: 'astral:shiva:test' });
+
+var TaskFatalError = require('ponos').TaskFatalError;
+var AWSValidationError = astralRequire('shiva/errors/aws-validation-error');
+
+describe('shiva', function() {
+  describe('errors', function() {
+    describe('AWSValidationError', function() {
+      it('should extend TaskFatalError', function(done) {
+        var err = new AWSValidationError(new Error('WOW'));
+        expect(err).to.be.an.instanceof(TaskFatalError);
+        done();
+      });
+
+      it('should set the message of the given error', function(done) {
+        var msg = 'This is an error message';
+        var err = new AWSValidationError(new Error(msg));
+        expect(err.message).to.equal(msg);
+        done();
+      });
+    }); // end 'AWSAlreadyExistsError'
+  }); // end 'errors'
+}); // end 'shiva'

--- a/test/shiva/unit/models/util.js
+++ b/test/shiva/unit/models/util.js
@@ -19,6 +19,7 @@ loadenv({ project: 'shiva', debugName: 'astral:shiva:test' });
 
 var Util = astralRequire('shiva/models/util');
 var AWSAlreadyExistsError = astralRequire('shiva/errors/aws-already-exists-error');
+var AWSValidationError = astralRequire('shiva/errors/aws-validation-error');
 
 describe('shiva', function() {
   describe('models', function () {
@@ -36,6 +37,19 @@ describe('shiva', function() {
             done();
           }
         });
+
+        it('should cast AWSValidationError', function (done) {
+          var awsError = new Error();
+          awsError.code = 'ValidationError';
+          try {
+            Util.castAWSError(awsError);
+          }
+          catch (err) {
+            expect(err).to.be.an.instanceof(AWSValidationError);
+            expect(err.data.originalError).to.equal(awsError);
+            done();
+          }
+        })
       }); // end'castAWSError
     }); // end 'Util'
   }); // end 'models'


### PR DESCRIPTION
It is possible, via the `asg.update` worker, to send invalid data to AWS via the sdk. Since a worker cannot continue when the job has invalid data, this PR casts AWS validation errors to task fatal errors at the model level.

Reviewers:
- [x] @bkendall 
- [x] @podviaznikov 
