### PR TITLE
Metis: Do Not Report Duplicate Webhook Entries

### DIFF
--- a/lib/metis/tasks/metis-github-event.js
+++ b/lib/metis/tasks/metis-github-event.js
@@ -82,11 +82,13 @@ function metisGithubEvent (job) {
     });
   })
   .catch(UniqueError, function (err) {
-    throw new TaskFatalError(
+    var fatalError = new TaskFatalError(
       'metis-github-event',
       'Job with given `deliveryId` has already been processed.',
       { job: job, originalError: err }
     );
+    fatalError.report = false;
+    throw fatalError;
   })
   .catch(NoGithubOrgError, function (err) {
     throw new TaskFatalError(

--- a/test/metis/unit/tasks/metis-github-event.js
+++ b/test/metis/unit/tasks/metis-github-event.js
@@ -118,18 +118,35 @@ describe('metis', function() {
           .catch(done);
       });
 
-      it('should fatally reject on a UniqueError', function(done) {
-        var job = {
-          deliveryId: 'some-delivery-id',
-          eventType: 'push',
-          recordedAt: 9241983,
-          payload: githubWebhooks.push.body
-        };
-        GitHubEvent.insert.returns(Promise.reject(new UniqueError()));
-        metisGithubEvent(job).asCallback(function (err) {
-          expect(err).to.be.an.instanceof(TaskFatalError);
-          expect(err.message).to.match(/deliveryId.*already.*processed/);
-          done();
+      describe('on UniqueError', function () {
+        it('should fatally reject', function (done) {
+          var job = {
+            deliveryId: 'some-delivery-id',
+            eventType: 'push',
+            recordedAt: 9241983,
+            payload: githubWebhooks.push.body
+          };
+          GitHubEvent.insert.returns(Promise.reject(new UniqueError()));
+          metisGithubEvent(job).asCallback(function (err) {
+            expect(err).to.be.an.instanceof(TaskFatalError);
+            expect(err.message).to.match(/deliveryId.*already.*processed/);
+            done();
+          });
+        });
+
+        it('should not report', function (done) {
+          var job = {
+            deliveryId: 'some-delivery-id',
+            eventType: 'push',
+            recordedAt: 9241983,
+            payload: githubWebhooks.push.body
+          };
+          GitHubEvent.insert.returns(Promise.reject(new UniqueError()));
+          metisGithubEvent(job).asCallback(function (err) {
+            expect(err).to.be.an.instanceof(TaskFatalError);
+            expect(err.report).to.be.false();
+            done();
+          });
         });
       });
 


### PR DESCRIPTION
Github provides a UUID for each of the webhook messages it sends, and metis uses this as a unique primary key when storing the information. When attempting to write webhook data the pgsql adapter will throw a uniqueness constraint violation which is turned into a `TaskFatalError` so that the job can be acked. This simply sets the fatal error to not report.

**Reviewers:**
- [x] @anandkumarpatel 
- [x] @Myztiq 
