### PR TITLE
add tls options for metis

### DIFF
--- a/lib/common/models/astral-redis.js
+++ b/lib/common/models/astral-redis.js
@@ -1,16 +1,31 @@
 'use strict';
 
+var fs = require('fs');
 var Promise = require('bluebird');
 var redis = require('redis');
+
+let tlsOptions;
+if (process.env.REDIS_CACERT) {
+  // ca is a string when encoding is passed into readFileSync
+  const caString = fs.readFileSync(process.env.REDIS_CACERT, 'utf-8');
+  tlsOptions = {
+    rejectUnauthorized: true,
+    ca: [ caString ]
+  };
+}
 
 /**
  * Redis Client.
  */
 Promise.promisifyAll(redis.RedisClient.prototype);
-var redisClient = redis.createClient({
+var redisOpts = {
   host: process.env.REDIS_HOST,
   port: process.env.REDIS_PORT
-});
+};
+if (tlsOptions) {
+  redisOpts.tls = tlsOptions;
+}
+var redisClient = redis.createClient(redisOpts);
 
 /**
  * Utility model for interacting with redis.


### PR DESCRIPTION
Allow us to define REDIS_CACERT to have metis connect to redis with tls
- [x] @rsandor 
#### tests
- [x] tested on epsilon
