### PR TITLE
Add new external event that should be handled by the task handler

### DIFF
--- a/lib/shiva/server.js
+++ b/lib/shiva/server.js
@@ -18,7 +18,7 @@ var tasks = {
 
 var events = {
   'dock.purged': require('./tasks/asg.instance.terminate'),
-  'asg.updated.requested': require('./tasks/asg.update')
+  'asg.update.requested': require('./tasks/asg.update')
 }
 
 var server = new ponos.Server({


### PR DESCRIPTION
Dock-cli and eru needs to request asg changes.
They need to publish event to exchange instead of task to the queue.

We do a trick by just adding event handler and using original task handler. That is done for now just to minimize impact of the PR.

**Note**
Exchanged should be first created. 
## Deploy
- [x] create exchange on gamma
- [ ] create exchange on delta
