### PR TITLE
Add logic for error handling

### DIFF
--- a/lib/shiva/errors/dock-not-detached-error.js
+++ b/lib/shiva/errors/dock-not-detached-error.js
@@ -1,0 +1,8 @@
+'use strict'
+const BaseError = require('error-cat/errors/base-error')
+
+module.exports = class DockNotDetachedError extends BaseError {
+  constructor (errMessage, originalError, reporting) {
+    super(errMessage, originalError, reporting)
+  }
+}

--- a/lib/shiva/tasks/dock.attach.js
+++ b/lib/shiva/tasks/dock.attach.js
@@ -1,6 +1,7 @@
 'use strict'
 const Promise = require('bluebird')
 const WorkerStopError = require('error-cat/errors/worker-stop-error')
+const DockNotDetachedError = require('../errors/dock-not-detached-error')
 require('loadenv')({ project: 'shiva', debugName: 'astral:shiva:env' })
 
 const AutoScalingGroup = require('../models/auto-scaling-group')
@@ -36,8 +37,9 @@ DockAttach.task = (job) => {
       throw new WorkerStopError('instance already attached to asg', { err, targetASGName })
     }
     if (!(new RegExp('is already part of AutoScalingGroup:' + process.env.DOCK_POOL_ASG_NAME).test(err.data.originalError.message))) {
-      throw err;
+      throw new DockNotDetachedError('Instance still not detached from pool', err, { level: 'info' })
     }
+      throw err;
   })
   .then(() => {
     return publisher.publishTask('dock.initialize', {


### PR DESCRIPTION
This will remove the common 'already part of AutoScalingGroup:delta-asg-dock-pool' error that happens when shiva attempts to attach a dock to an org's asg that has not been detached from the dock pool fast enough